### PR TITLE
Adding isoweek and python-dateutil to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6'
     ],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'wagtail>=1.9.1',
+        'wagtail>=1.8.0',
         'isoweek==1.1.0',
         'python-dateutil==2.6.0'
     ],

--- a/setup.py
+++ b/setup.py
@@ -5,27 +5,32 @@ from wagtail_events import __version__
 from setuptools import setup, find_packages
 
 setup(
-      name='omni_wagtail_events',
-      version=__version__,
-      description='Event features for Wagtail',
-      author='Omni Digital',
-      author_email='dev@omni-digital.co.uk',
-      url='https://github.com/omni-digital/omni-wagtail-events',
-      download_url='https://github.com/omni-digital/omni-wagtail-events/tarball/0.1.0',
-      packages=find_packages(),
-      license='MIT',
-      classifiers=[
-            'Development Status :: 4 - Beta',
-            'Intended Audience :: Developers',
-            'Topic :: Software Development :: Libraries :: Python Modules',
-            'License :: OSI Approved :: MIT License',
-            'Programming Language :: Python :: 2',
-            'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.4',
-            'Programming Language :: Python :: 3.5'
-            'Programming Language :: Python :: 3.6'
-      ],
-      include_package_data=True,
-      keywords=['wagtail', 'django', 'events']
+    name='omni_wagtail_events',
+    version=__version__,
+    description='Event features for Wagtail',
+    author='Omni Digital',
+    author_email='dev@omni-digital.co.uk',
+    url='https://github.com/omni-digital/omni-wagtail-events',
+    download_url='https://github.com/omni-digital/omni-wagtail-events/tarball/0.1.0',
+    packages=find_packages(),
+    license='MIT',
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
+    ],
+    include_package_data=True,
+    install_requires=[
+        'wagtail>=1.9.1',
+        'isoweek==1.1.0',
+        'python-dateutil==2.6.0'
+    ],
+    keywords=['wagtail', 'django', 'events']
 )

--- a/wagtail_events/__init__.py
+++ b/wagtail_events/__init__.py
@@ -6,4 +6,4 @@ Event library for Wagtail
 from __future__ import unicode_literals
 
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'


### PR DESCRIPTION
Fixes https://github.com/omni-digital/omni-wagtail-events/issues/5

# Changes

* Fixed indentation in setup.py
* Added install_requires
* Bumped version
* Added a missing trailing comma