### PR TITLE
Pagination constructor args customisation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 django==1.10
 isoweek==1.1.0
+mock==2.0.0
 psycopg2==2.7.1
 python-dateutil==2.6.0
 wagtail==1.9.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36}-dj{18,19,110}-wag{18,19,110,111},py35-flake8
+envlist = {py27,py34,py35,py36}-dj{110,111}-wag{111,112},py35-flake8
 
 [testenv]
 setenv =
@@ -9,19 +9,16 @@ commands =
     coverage run --source wagtail_events runtests.py
     coverage report --show-missing
 deps =
-    dj18: Django>=1.8,<1.9
-    dj19: Django>=1.9,<1.10
     dj110: Django>=1.10,<1.11
+    dj111: Django>=1.11,<1.12
     coverage==4.2.0
     factory-boy==2.8.1
     isoweek==1.1.0
     mock==2.0.0
     psycopg2==2.7.1
     python-dateutil==2.6.0
-    wag18: wagtail>=1.8,<1.9
-    wag19: wagtail>=1.9,<1.10
-    wag10: wagtail>=1.10,<1.11
-    wag11: wagtail>=1.11,<1.12
+    wag111: wagtail>=1.11,<1.12
+    wag112: wagtail>=1.12,<1.13
     wagtail-factories==0.3.0
 
 [testenv:py35-flake8]

--- a/wagtail_events/__init__.py
+++ b/wagtail_events/__init__.py
@@ -6,4 +6,4 @@ Event library for Wagtail
 from __future__ import unicode_literals
 
 
-__version__ = '1.0.1'
+__version__ = '1.1.0'

--- a/wagtail_events/abstract_models.py
+++ b/wagtail_events/abstract_models.py
@@ -15,6 +15,7 @@ class AbstractPaginatedIndex(Page):
     """ """
     paginate_by = models.PositiveIntegerField(blank=True, null=True)
     content_panels = Page.content_panels + [FieldPanel('paginate_by')]
+    paginator_class = Paginator
 
     class Meta(object):
         """Django model meta options."""
@@ -33,7 +34,34 @@ class AbstractPaginatedIndex(Page):
             children = children.filter(live=True)
         return children
 
-    def _paginate_queryset(self, queryset, page):
+    def get_paginator_class(self):
+        """
+        Returns the class to use for pagination
+
+        :return: Paginator class
+        """
+        return self.paginator_class
+
+    def get_paginator_kwargs(self):
+        """
+        Method for generating a dict of keyword args that will be
+        passed to the paginator constructor
+
+        :param request: HttpRequest instance
+        :return: Dict of keyword arguments to pass to the paginator class constructor
+        """
+        return {}
+
+    def get_paginator(self, *args, **kwargs):
+        """
+        Returns a paginator instance
+
+        :return: Paginator class
+        """
+        paginator_class = self.get_paginator_class()
+        return paginator_class(*args, **kwargs)
+
+    def paginate_queryset(self, queryset, page):
         """
         Helper method for paginating the queryset provided.
 
@@ -41,7 +69,11 @@ class AbstractPaginatedIndex(Page):
         :param page: Raw page number taken from the request dict
         :return: Queryset of child model instances
         """
-        paginator = Paginator(queryset, self.paginate_by)
+        paginator = self.get_paginator(
+            queryset,
+            self.paginate_by,
+            **self.get_paginator_kwargs()
+        )
         try:
             queryset = paginator.page(page)
         except PageNotAnInteger:
@@ -71,9 +103,10 @@ class AbstractPaginatedIndex(Page):
         # Paginate the child nodes if paginate_by has been specified
         if self.paginate_by:
             is_paginated = True
-            queryset['items'], paginator = self._paginate_queryset(
+            page_num = request.GET.get('page', 1) or 1
+            queryset['items'], paginator = self.paginate_queryset(
                 queryset['items'],
-                request.GET.get('page')
+                page_num
             )
 
         context.update(


### PR DESCRIPTION
# The problem

* It is not easy to swap the pagination class without overriding the entire _paginate_queryset method
* The _paginate_queryset method should be overridable/public

# Solution

* Made existing pagination related methods public
* Added new methods for providing easier pagination customisation

# Note

I have checked the dependant projects that use this package for obvious regressions.  I have not found any implementation which subclasses any of the pagination related methods so am confident that this release will not cause any problems when the dependant projects are updated.  If, however, I have missed something please let me know